### PR TITLE
In NetworkManager I added method downloadImage.

### DIFF
--- a/PeliculaApp/Custom Views/Cells/MovieCell.swift
+++ b/PeliculaApp/Custom Views/Cells/MovieCell.swift
@@ -51,7 +51,9 @@ class MovieCell: UITableViewCell {
     
     
     func set(movie: Movie) {
-        movieImageView.load(url: movie.posterURL)
+        NetworkManager.shared.downloadImage(url: movie.posterURL) { image in
+            self.movieImageView.image = image
+        }
         movieTitleLabel.text    = movie.title
         movieOverview.text      = movie.overview
         dateLabel.text          = MovieCell.dateFormatter.string(from: movie.releaseDate)

--- a/PeliculaApp/Model/Movie.swift
+++ b/PeliculaApp/Model/Movie.swift
@@ -18,7 +18,8 @@ public struct MoviesResponse: Codable {
 }
 
 
-public struct Movie: Codable {
+public struct Movie: Codable, Hashable {
+    
     
     public let id: Int
     public let title: String
@@ -40,6 +41,9 @@ public struct Movie: Codable {
 }
 
 
-public struct MovieGenre: Codable {
+public struct MovieGenre: Codable, Hashable {
     let name: String
 }
+
+
+

--- a/PeliculaApp/Screens/MovieScreenVC.swift
+++ b/PeliculaApp/Screens/MovieScreenVC.swift
@@ -79,8 +79,14 @@ class MovieScreenVC: UIViewController {
                 print(movie)
                 
                 DispatchQueue.main.async {
-                    self.backdropImageView.load(url: movie.backdropURL)
-                    self.posterImageView.load(url: movie.posterURL)
+                    //self.backdropImageView.load(url: movie.backdropURL)
+                    NetworkManager.shared.downloadImage(url: movie.backdropURL) { image in
+                        self.backdropImageView.image = image
+                    }
+                    //self.posterImageView.load(url: movie.posterURL)
+                    NetworkManager.shared.downloadImage(url: movie.posterURL) { image in
+                        self.posterImageView.image = image
+                    }
                     self.movieTitleLabel.text = movie.title
                     self.scoreLabel.text      = String(movie.voteAverage)
                     self.releaseLabel.text    = "Release time: \(MovieScreenVC.dateFormatter.string(from: movie.releaseDate))"


### PR DESCRIPTION
In that method you can cache images.
This solves the problem with the download of images every time a UITableView is being scrolled.